### PR TITLE
add TagBot CI

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,0 +1,15 @@
+name: TagBot
+on:
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
+jobs:
+  TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JuliaRegistries/TagBot@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.TAGBOT }}


### PR DESCRIPTION
[TagBot](https://github.com/JuliaRegistries/TagBot) is used to automatically generate tags and release notes in https://github.com/Longhao-Chen/BM3DDenoise.jl/releases page, since we register this package in Julia General, I feel we need this.